### PR TITLE
Pre-populate relations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,9 @@ export type {
   IndexerFn,
   FlattenFn,
   ModelTestFn,
+  StrapiAttribute,
+  StrapiAttributeType,
+  AttributePopulate,
 } from './types';
 export type {
   Reference,

--- a/src/types.ts
+++ b/src/types.ts
@@ -278,8 +278,31 @@ export interface StrapiAttribute {
   configurable?: boolean
   writable?: boolean
 
+  /**
+   * Controls how this attribute should be indexed. Applies to component
+   * models only, and only when embedded as a repeatable or dynamic-zone component.
+   * 
+   * Non-standard API, Firestore connector only.
+   */
   index?: true | string | { [key: string]: true | IndexerFn }
+
+  
+  /**
+   * Controls how this relation should be pre-populated in the Firestore database.
+   * Applies to relation attributes only.
+   * 
+   * Non-standard API, Firestore connector only.
+   */
+  populate?: AttributePopulate
+
+  /**
+   * @private Internal Firestore connector use only.
+   */
   isMeta?: boolean
+}
+
+export interface AttributePopulate {
+  [key: string]: string | string[]
 }
 
 export interface IndexerFn {


### PR DESCRIPTION
Closes #45 

- [x] Configuration API
- [ ] Store target data when updating source document
- [ ] Update data in source document when updating the target
- [ ] Deep (multi-level) populating
- [ ] Enforce attribute overlap rules (i.e. attribute called `name.first` can't overlap with attribute called `name`)