### PR TITLE
Implement set write operation

### DIFF
--- a/src/coerce/coerce-to-model.ts
+++ b/src/coerce/coerce-to-model.ts
@@ -19,8 +19,10 @@ export class CoercionError extends StatusError {
   }
 }
 
+export type EditMode = 'create' | 'update' | 'set' | 'setMerge' | 'delete';
+
 export interface CoerceOpts {
-  editMode?: 'create' | 'update'
+  editMode?: EditMode
   timestamp?: Date
 }
 

--- a/src/db/morph-reference.ts
+++ b/src/db/morph-reference.ts
@@ -1,9 +1,10 @@
 import * as _ from 'lodash';
 import { DeepReference } from './deep-reference';
 import type { Collection } from './collection';
-import { MorphReferenceShape, Reference, SetOpts } from './reference';
+import { MorphReferenceShape, Reference, UpdateOpts, SetOpts } from './reference';
 import { NormalReference } from './normal-reference';
 import { VirtualReference } from './virtual-reference';
+import type { EditMode } from '../coerce/coerce-to-model';
 
 
 /**
@@ -32,20 +33,26 @@ export class MorphReference<T extends object> extends Reference<T> {
     return this.ref.firestore;
   }
 
-  delete(opts?: SetOpts) {
-    return this.ref.delete();
+  delete(opts?: UpdateOpts) {
+    return this.ref.delete(opts);
   };
 
-  create(data: T, opts?: SetOpts): Promise<T>
-  create(data: Partial<T>, opts?: SetOpts): Promise<Partial<T>>
-  create(data: T | Partial<T>, opts?: SetOpts): Promise<T | Partial<T>> {
+  create(data: T, opts?: UpdateOpts): Promise<T>
+  create(data: Partial<T>, opts?: UpdateOpts): Promise<Partial<T>>
+  create(data: T | Partial<T>, opts?: UpdateOpts): Promise<T | Partial<T>> {
     return this.ref.create(data, opts);
-  };
+  }
 
-  update(data: T, opts?: SetOpts): Promise<T>
-  update(data: Partial<T>, opts?: SetOpts): Promise<Partial<T>>
-  update(data: Partial<T>, opts?: SetOpts) {
+  update(data: T, opts?: UpdateOpts): Promise<T>
+  update(data: Partial<T>, opts?: UpdateOpts): Promise<Partial<T>>
+  update(data: Partial<T>, opts?: UpdateOpts) {
     return this.ref.update(data, opts);
+  }
+
+  set(data: T, opts?: SetOpts): Promise<T>
+  set(data: Partial<T>, opts?: SetOpts): Promise<Partial<T>>
+  set(data: Partial<T>, opts?: SetOpts) {
+    return this.ref.set(data, opts);
   }
 
   /**
@@ -53,7 +60,7 @@ export class MorphReference<T extends object> extends Reference<T> {
    * @private
    * @deprecated For internal connector use only
    */
-  writeInternal(data: Partial<T> | undefined, editMode: 'create' | 'update') {
+  writeInternal(data: Partial<T> | undefined, editMode: EditMode) {
     return this.ref.writeInternal(data, editMode);
   }
 

--- a/src/db/normal-reference.ts
+++ b/src/db/normal-reference.ts
@@ -1,8 +1,9 @@
 import * as _ from 'lodash';
 import type { DocumentReference, DocumentSnapshot } from '@google-cloud/firestore';
-import { Reference, SetOpts, Snapshot } from './reference';
+import { Reference, UpdateOpts, SetOpts, Snapshot } from './reference';
 import type { NormalCollection } from './normal-collection';
-import { runUpdateLifecycle } from '../utils/lifecycle';
+import { runUpdateLifecycle, guardEditMode } from '../utils/lifecycle';
+import type { EditMode } from '../coerce/coerce-to-model';
 
 /**
  * Acts as a wrapper around a native `DocumentReference`,
@@ -25,9 +26,9 @@ export class NormalReference<T extends object> extends Reference<T> {
     return this.ref.firestore;
   }
 
-  async delete(opts?: SetOpts) {
+  async delete(opts?: UpdateOpts) {
     await runUpdateLifecycle({
-      editMode: 'update',
+      editMode: 'delete',
       ref: this,
       data: undefined,
       opts,
@@ -35,9 +36,9 @@ export class NormalReference<T extends object> extends Reference<T> {
     });
   }
 
-  async create(data: T, opts?: SetOpts): Promise<T>
-  async create(data: Partial<T>, opts?: SetOpts): Promise<Partial<T>>
-  async create(data: T | Partial<T>, opts?: SetOpts) {
+  async create(data: T, opts?: UpdateOpts): Promise<T>
+  async create(data: Partial<T>, opts?: UpdateOpts): Promise<Partial<T>>
+  async create(data: T | Partial<T>, opts?: UpdateOpts) {
     return await runUpdateLifecycle({
       editMode: 'create',
       ref: this,
@@ -47,11 +48,23 @@ export class NormalReference<T extends object> extends Reference<T> {
     });
   }
 
-  update(data: T, opts?: SetOpts): Promise<T>
-  update(data: Partial<T>, opts?: SetOpts): Promise<Partial<T>>
-  async update(data: T | Partial<T>, opts?: SetOpts) {
+  update(data: T, opts?: UpdateOpts): Promise<T>
+  update(data: Partial<T>, opts?: UpdateOpts): Promise<Partial<T>>
+  async update(data: T | Partial<T>, opts?: UpdateOpts) {
     return await runUpdateLifecycle({
       editMode: 'update',
+      ref: this,
+      data,
+      opts,
+      timestamp: new Date(),
+    });
+  }
+
+  set(data: T, opts?: SetOpts): Promise<T>
+  set(data: Partial<T>, opts?: SetOpts): Promise<Partial<T>>
+  async set(data: T | Partial<T>, opts?: SetOpts) {
+    return await runUpdateLifecycle({
+      editMode: opts?.merge ? 'setMerge' : 'set',
       ref: this,
       data,
       opts,
@@ -65,17 +78,28 @@ export class NormalReference<T extends object> extends Reference<T> {
    * @private
    * @deprecated For internal connector use only
    */
-  async writeInternal(data: Partial<T> | undefined, editMode: 'create' | 'update') {
-    if (data) {
-      if (editMode === 'create') {
-        await this.ref.create(data as T);
-      } else {
-        // Firestore does not run the converter on update operations
-        const out = this.parent.converter.toFirestore(data as T);
-        await this.ref.update(out);
-      }
-    } else {
+  async writeInternal(data: Partial<T> | undefined, editMode: EditMode) {
+    if (!data || (editMode === 'delete')) {
       await this.ref.delete();
+    } else {
+      switch (editMode) {
+        case 'create':
+          await this.ref.create(data as T);
+          break;
+        case 'update':
+          // Firestore does not run the converter on update operations
+          const out = this.parent.converter.toFirestore(data as T);
+          await this.ref.update(out);
+          break;
+        case 'set':
+          await this.ref.set(data as T);
+          break;
+        case 'setMerge':
+          await this.ref.set(data as T, { merge: true });
+          break;
+        default:
+          guardEditMode(editMode);
+      }
     }
   }
 

--- a/src/db/readonly-transaction.ts
+++ b/src/db/readonly-transaction.ts
@@ -1,10 +1,11 @@
-import type { Transaction as FirestoreTransaction, Firestore } from '@google-cloud/firestore';
+import type { Firestore } from '@google-cloud/firestore';
 import { ReadRepository } from '../utils/read-repository';
 import type { Queryable, QuerySnapshot } from './collection';
-import type { Reference, SetOpts, Snapshot } from './reference';
+import type { Reference, UpdateOpts, SetOpts, Snapshot } from './reference';
 import { VirtualReference } from './virtual-reference';
 import type { GetOpts, Transaction } from './transaction';
 import { get, getAll, getRefInfo } from './readwrite-transaction';
+import type { EditMode } from '../coerce/coerce-to-model';
 
 
 export class ReadOnlyTransaction implements Transaction {
@@ -15,7 +16,7 @@ export class ReadOnlyTransaction implements Transaction {
   /**
    * @deprecated Not supported on ReadonlyTransaction
    */
-  get nativeTransaction(): FirestoreTransaction {
+  get nativeTransaction(): never {
     throw new Error('nativeTransaction is not supported on ReadonlyTransaction');
   }
 
@@ -33,10 +34,10 @@ export class ReadOnlyTransaction implements Transaction {
   /**
    * @deprecated Not supported on ReadOnlyTransaction
    */
-  getAtomic<T extends object>(ref: Reference<T>, opts?: GetOpts): Promise<Snapshot<T>>
-  getAtomic<T extends object>(refs: Reference<T>[], opts?: GetOpts): Promise<Snapshot<T>[]>
-  getAtomic<T extends object>(query: Queryable<T>): Promise<QuerySnapshot<T>>
-  getAtomic<T extends object>(): Promise<Snapshot<T> | Snapshot<T>[] | QuerySnapshot<T>> {
+  getAtomic<T extends object>(ref: Reference<T>, opts?: GetOpts): never
+  getAtomic<T extends object>(refs: Reference<T>[], opts?: GetOpts): never
+  getAtomic<T extends object>(query: Queryable<T>): never
+  getAtomic(): never {
     throw new Error('getAtomic() is not supported on ReadOnlyTransaction');
   }
   
@@ -63,9 +64,9 @@ export class ReadOnlyTransaction implements Transaction {
   }
 
 
-  create<T extends object>(ref: Reference<T>, data: T, opts?: SetOpts): Promise<T>
-  create<T extends object>(ref: Reference<T>, data: Partial<T>, opts?: SetOpts): Promise<Partial<T>>
-  async create<T extends object>(ref: Reference<T>, data: T | Partial<T>, opts?: SetOpts): Promise<T | Partial<T>> {
+  create<T extends object>(ref: Reference<T>, data: T, opts?: UpdateOpts): Promise<T>
+  create<T extends object>(ref: Reference<T>, data: Partial<T>, opts?: UpdateOpts): Promise<Partial<T>>
+  async create<T extends object>(ref: Reference<T>, data: T | Partial<T>, opts?: UpdateOpts): Promise<T | Partial<T>> {
     if (ref instanceof VirtualReference) {
       return await ref.create(data, opts);
     } else {
@@ -73,13 +74,23 @@ export class ReadOnlyTransaction implements Transaction {
     }
   }
   
-  update<T extends object>(ref: Reference<T>, data: T, opts?: SetOpts): Promise<T>
-  update<T extends object>(ref: Reference<T>, data: Partial<T>, opts?: SetOpts): Promise<Partial<T>>
-  async update<T extends object>(ref: Reference<T>, data: T | Partial<T>, opts?: SetOpts): Promise<T | Partial<T>> {
+  update<T extends object>(ref: Reference<T>, data: T, opts?: UpdateOpts): Promise<T>
+  update<T extends object>(ref: Reference<T>, data: Partial<T>, opts?: UpdateOpts): Promise<Partial<T>>
+  async update<T extends object>(ref: Reference<T>, data: T | Partial<T>, opts?: UpdateOpts): Promise<T | Partial<T>> {
     if (ref instanceof VirtualReference) {
       return await ref.update(data, opts);
     } else {
       throw new Error('update() is not supported on ReadOnlyTransaction');
+    }
+  }
+
+  set<T extends object>(ref: Reference<T>, data: T, opts?: SetOpts): Promise<T>
+  set<T extends object>(ref: Reference<T>, data: Partial<T>, opts?: SetOpts): Promise<Partial<T>>
+  async set<T extends object>(ref: Reference<T>, data: T | Partial<T>, opts?: UpdateOpts): Promise<T | Partial<T>> {
+    if (ref instanceof VirtualReference) {
+      return await ref.set(data, opts);
+    } else {
+      throw new Error('set() is not supported on ReadOnlyTransaction');
     }
   }
   
@@ -99,7 +110,7 @@ export class ReadOnlyTransaction implements Transaction {
    * @private
    * @deprecated For internal connector use only
    */
-  mergeWriteInternal<T extends object>(ref: Reference<T>, data: Partial<T> | undefined, editMode: 'create' | 'update') {
+  mergeWriteInternal<T extends object>(ref: Reference<T>, data: Partial<T> | undefined, editMode: EditMode) {
     const { docRef } = getRefInfo(ref);
     if (!docRef) {
       (ref as VirtualReference<T>).writeInternal(data, editMode);

--- a/src/db/readwrite-transaction.ts
+++ b/src/db/readwrite-transaction.ts
@@ -1,23 +1,25 @@
+import * as _ from 'lodash';
 import { DocumentReference, Transaction as FirestoreTransaction, DocumentData, Firestore, DocumentSnapshot, FirestoreDataConverter } from '@google-cloud/firestore';
 import { DeepReference, makeDeepSnap, mapToFlattenedDoc } from './deep-reference';
 import { ReadRepository, RefAndMask } from '../utils/read-repository';
 import type { Queryable, QuerySnapshot } from './collection';
-import { Reference, SetOpts, Snapshot } from './reference';
+import { Reference, UpdateOpts, SetOpts, Snapshot } from './reference';
 import { MorphReference } from './morph-reference';
 import { makeNormalSnap, NormalReference } from './normal-reference';
-import { runUpdateLifecycle } from '../utils/lifecycle';
+import { runUpdateLifecycle, guardEditMode } from '../utils/lifecycle';
 import { VirtualReference } from './virtual-reference';
 import type { GetOpts, Transaction } from './transaction';
+import type { EditMode } from '../coerce/coerce-to-model';
 
 
 export class ReadWriteTransaction implements Transaction {
   
-  private readonly writes = new Map<string, WriteOp>();
+  private readonly writes = new Map<string, WriteOp[]>();
 
   private readonly timestamp = new Date();
   private readonly atomicReads: ReadRepository;
   private readonly nonAtomicReads: ReadRepository;
-  private readonly ensureFlatCollections: Promise<void>[] = [];
+  private readonly flatCollections = new Map<string, Promise<void>>();
 
 
   constructor(
@@ -65,34 +67,68 @@ export class ReadWriteTransaction implements Transaction {
    * @deprecated For internal connector use only
    */
   async commit() {
+
+
+    // Flatten writes to any deep references down to the native document
+    const nativeWrites = new Map<string, WriteOp>();
+    for (const ops of this.writes.values()) {
+      for (const op of ops) {
+        const { docRef, deepRef } = getRefInfo(op.ref);
+        if (!docRef) {
+          (op.ref as VirtualReference<any>).writeInternal(op.data || undefined, op.mode);
+          break;
+        }
+      }
+
+      const { docRef, deepRef } = getRefInfo(op.re);
+      if (!docRef) {
+        (ref as VirtualReference<T>).writeInternal(data, editMode);
+        return;
+      }
+
+    }
+
+
     if (this.logStats) {
-      strapi.log.debug(`TRANSACTION (attempt #${this.attempt}): ${this.writes.size} writes, ${this.atomicReads.readCount + this.nonAtomicReads.readCount} reads (${this.atomicReads.readCount} atomic).`);
+      strapi.log.debug(`TRANSACTION (attempt #${this.attempt}): ${nativeWrites.size} writes, ${this.atomicReads.readCount + this.nonAtomicReads.readCount} reads (${this.atomicReads.readCount} atomic).`);
     }
 
     // If we have fetched flat documents then we need to wait to
-    // ensure that the document exists so that the update
-    // operate will succeed
-    await Promise.all(this.ensureFlatCollections);
+    // ensure that the document exists so that the update operate will succeed
+    await Promise.all([...this.flatCollections.values()]);
 
-    for (const op of this.writes.values()) {
-      if (op.data === null) {
-        this.nativeTransaction.delete(op.ref)
-      } else {
-        if (op.create) {
-          this.nativeTransaction.create(op.ref, op.data);
-        } else {
-          // Firestore does not run the converter on update operations
-          op.data = op.converter.toFirestore(op.data);
-          this.nativeTransaction.update(op.ref, op.data);
+
+    for (const ops of this.writes.values()) {
+      for (const op of ops) {
+        switch (op.mode) {
+          case 'delete':
+            this.nativeTransaction.delete(op.ref);
+            break;
+          case 'create':
+            this.nativeTransaction.create(op.ref, op.data);
+            break;
+          case 'update':
+            // Firestore does not run the converter on update operations
+            op.data = op.converter.toFirestore(op.data);
+            this.nativeTransaction.update(op.ref, op.data!);
+            break;
+          case 'set':
+            this.nativeTransaction.set(op.ref, op.data);
+            break;
+          case 'setMerge':
+            this.nativeTransaction.set(op.ref, op.data!, { merge: true });
+            break;
+          default:
+            guardEditMode(op.mode);
         }
       }
     }
   }
 
 
-  create<T extends object>(ref: Reference<T>, data: T, opts?: SetOpts): Promise<T>
-  create<T extends object>(ref: Reference<T>, data: Partial<T>, opts?: SetOpts): Promise<Partial<T>>
-  async create<T extends object>(ref: Reference<T>, data: T | Partial<T>, opts?: SetOpts): Promise<T | Partial<T>> {
+  create<T extends object>(ref: Reference<T>, data: T, opts?: UpdateOpts): Promise<T>
+  create<T extends object>(ref: Reference<T>, data: Partial<T>, opts?: UpdateOpts): Promise<Partial<T>>
+  async create<T extends object>(ref: Reference<T>, data: T | Partial<T>, opts?: UpdateOpts): Promise<T | Partial<T>> {
     return (await runUpdateLifecycle({
       editMode: 'create',
       ref,
@@ -103,9 +139,9 @@ export class ReadWriteTransaction implements Transaction {
     }))!;
   }
   
-  update<T extends object>(ref: Reference<T>, data: T, opts?: SetOpts): Promise<T>
-  update<T extends object>(ref: Reference<T>, data: Partial<T>, opts?: SetOpts): Promise<Partial<T>>
-  async update<T extends object>(ref: Reference<T>, data: T | Partial<T>, opts?: SetOpts): Promise<T | Partial<T>> {
+  update<T extends object>(ref: Reference<T>, data: T, opts?: UpdateOpts): Promise<T>
+  update<T extends object>(ref: Reference<T>, data: Partial<T>, opts?: UpdateOpts): Promise<Partial<T>>
+  async update<T extends object>(ref: Reference<T>, data: T | Partial<T>, opts?: UpdateOpts): Promise<T | Partial<T>> {
     return (await runUpdateLifecycle({
       editMode: 'update',
       ref,
@@ -115,10 +151,23 @@ export class ReadWriteTransaction implements Transaction {
       timestamp: this.timestamp,
     }))!;
   }
+
+  set<T extends object>(ref: Reference<T>, data: T, opts?: SetOpts): Promise<T>
+  set<T extends object>(ref: Reference<T>, data: Partial<T>, opts?: SetOpts): Promise<Partial<T>>
+  async set<T extends object>(ref: Reference<T>, data: T | Partial<T>, opts?: SetOpts): Promise<T | Partial<T>> {
+    return (await runUpdateLifecycle({
+      editMode: opts?.merge ? 'setMerge' : 'set',
+      ref,
+      data,
+      opts,
+      transaction: this,
+      timestamp: this.timestamp,
+    }))!;
+  }
   
-  async delete<T extends object>(ref: Reference<T>, opts?: SetOpts): Promise<void> {
+  async delete<T extends object>(ref: Reference<T>, opts?: UpdateOpts): Promise<void> {
     await runUpdateLifecycle({
-      editMode: 'update',
+      editMode: 'delete',
       ref,
       data: undefined,
       opts,
@@ -135,63 +184,156 @@ export class ReadWriteTransaction implements Transaction {
    * @private
    * @deprecated For internal connector use only
    */
-  mergeWriteInternal<T extends object>(ref: Reference<T>, data: Partial<T> | undefined, editMode: 'create' | 'update') {
+  mergeWriteInternal<T extends object>(ref: Reference<T>, data: Partial<T> | undefined, editMode: EditMode) {
 
-    const { docRef, deepRef } = getRefInfo(ref);
-    if (!docRef) {
-      (ref as VirtualReference<T>).writeInternal(data, editMode);
-      return;
-    }
-
-    const { path } = docRef;
-
-    let op: WriteOp;
-    if (this.writes.has(path)) {
-      op = this.writes.get(path)!;
-    } else {
-      op = {
-        ref: docRef,
-        data: {},
-        create: false,
-        converter: ref.parent.converter,
-      };
-      this.writes.set(path, op);
-
-      // If the write is for a flattened collection
-      // then pre-emptively start ensuring that the document exists
-      if (deepRef) {
-        this.ensureFlatCollections.push(deepRef.parent.ensureDocument());
+    // If the write is for a flattened collection then pre-emptively start ensuring that the document exists
+    if (ref instanceof DeepReference) {
+      if (!this.flatCollections.get(ref.parent.path)) {
+        this.flatCollections.set(ref.parent.path, ref.parent.ensureDocument());
       }
     }
 
-    if (op.data === null) {
-      // Deletion overrides all other operations
-      return;
+    // Get existing or put new array of writes for this document
+    let ops: WriteOp[] = this.writes.get(ref.path) || (() => {
+      const ops: WriteOp[] = [];
+      this.writes.set(ref.path, ops);
+      return ops;
+    })();
+
+    // Create new op
+    let op: WriteOp
+    if (editMode === 'delete') {
+     op = { ref, data: null, mode: 'delete' };
+    } else {
+      if (!data) {
+        throw new Error(`Data for ${editMode} operation is undefined`);
+      }
+      op = { ref, data, mode: editMode };
     }
+
+    const lastOp = ops[ops.length - 1] as WriteOp | undefined;
+
+    // Merge data and ensure feasibility
+    switch (op.mode) {
+      case 'create':
+        switch (lastOp?.mode) {
+          case 'delete':
+            // Create will replace the delete so issue a warning
+            // then fall through to the next clause
+            warnMergeOverridingData(op.mode, ref);
+
+          case undefined:
+            ops.splice(0, ops.length, op);
+            break;
+
+          case 'create':
+          case 'update':
+          case 'set':
+          case 'setMerge':
+            // Create operation requires that the document not exist
+            throw new WriteCannotSucceedError(op.mode, lastOp.mode);
+
+          default:
+            guardEditMode(lastOp);
+        }
+        break;
+
+      case 'setMerge':
+      case 'update':
+        switch (lastOp?.mode) {
+          case undefined:
+            // No previous ops, so we append
+            ops.push(op);
+            break;
+
+          case 'delete':
+            if (op.mode === 'update') {
+              // Update operation requires that the document exists
+              throw new WriteCannotSucceedError(op.mode, lastOp.mode);
+            } else {
+              warnMergeOverridingData(op.mode, ref);
+              ops.splice(0, ops.length, op);
+            }
+            break;
+            
+          case 'create':
+          case 'set':
+          case 'setMerge':
+            if ((op.mode === 'update') && Object.keys(op.data).some(key => key.includes('.'))) {
+              // Update operation has nested paths (path with ".")
+              // Such paths are only supported in update operations and the previous operation is not an update
+              // So we cannot merge but instead need to append
+              ops.push(op);
+              break;
+            } else {
+              // We can merge, so fall through to the next clause 
+            }
+
+          case 'update':
+            // Ok, we can merge the data, but keep existing mode
+            // update mode does not override create, update, set, or setMerge (all assure that the document already exists)
+            // setMerge mode does not override create, update, set, or setMerge
+            let isKeysOverwritten = false;
+            for (const key of Object.keys(data!)) {
+              if (_.get(lastOp.data, key) !== undefined) {
+                isKeysOverwritten = true;
+              }
+              _.set(lastOp.data, key, op.data[key]);
+            }
+            break;
+
+          default:
+            guardEditMode(lastOp);
+        }
+        break;
+
+      case 'set':
+      case 'delete':
+        // Always feasible
+        // Clear all existing operations and add the new one
+        if (ops.length) {
+          warnMergeOverridingData(op.mode, ref);
+        }
+        ops.splice(0, ops.length, op);
+        break;
+
+
+      default:
+        guardEditMode(op);
+    }
+
+
+    // if (op.data === null) {
+    //   // Deletion overrides all other operations
+    //   return;
+    // }
 
     // Don't create documents for flattened collections
     // because we use ensureDocument() and then update()
-    op.create = op.create || ((editMode === 'create') && !deepRef) || false;
+    // op.create = op.create || ((editMode === 'create') && !deepRef) || false;
 
-    if (deepRef) {
-      Object.assign(op.data, mapToFlattenedDoc(deepRef, data, true));
-    } else {
-      if (!data) {
-        op.data = null;
-      } else {
-        Object.assign(op.data, data);
-      }
-    }
+    // if (deepRef) {
+    //   Object.assign(op.data, mapToFlattenedDoc(deepRef, data, true));
+    // } else {
+    //   if (!data) {
+    //     op.data = null;
+    //   } else {
+    //     Object.assign(op.data, data);
+    //   }
+    // }
   }
 }
 
 
-interface WriteOp {
-  ref: DocumentReference
-  data: DocumentData | null
-  create: boolean
-  converter: FirestoreDataConverter<any>
-}
+type WriteOp = {
+  ref: Reference<any>
+} & ({
+  data: DocumentData
+  mode: 'create' | 'update' | 'set' | 'setMerge'
+} | {
+  data: null
+  mode: 'delete'
+})
 
 interface RefInfo {
   docRef?: DocumentReference<any>,
@@ -283,4 +425,14 @@ function makeSnap(ref: Reference<any>, snap: DocumentSnapshot<any>): Snapshot<an
     }
   }
   throw new Error('Unknown type of reference');
+}
+
+function warnMergeOverridingData(editMode: EditMode, ref: Reference<any>) {
+  strapi.log.warn(`${editMode} is overwriting the data from one or more previous write operations for ${ref.path}`);
+}
+
+export class WriteCannotSucceedError extends Error {
+  constructor(thisOperation: EditMode, previousOperation: EditMode) {
+    super(`${thisOperation} can never succeed following a ${previousOperation}`);
+  }
 }

--- a/src/db/reference.ts
+++ b/src/db/reference.ts
@@ -54,10 +54,10 @@ export interface Snapshot<T extends object> {
 }
 
 
-export interface SetOpts {
+export interface UpdateOpts {
   /**
    * Indicates whether relation links should be updated on
-   * other related documents. This can extra reads, queries
+   * other related documents. This can cause extra reads, queries
    * and writes to multiple documents.
    * 
    * If not updated, reference links will get into invalid states,
@@ -66,6 +66,13 @@ export interface SetOpts {
    * Defaults to `true`.
    */
   updateRelations?: boolean
+}
+
+export interface SetOpts extends UpdateOpts {
+  /**
+   * 
+   */
+  merge?: boolean;
 }
 
 /**
@@ -81,19 +88,25 @@ export abstract class Reference<T extends object> {
 
   abstract readonly firestore: Firestore;
 
-  abstract delete(opts?: SetOpts): Promise<void>;
+  abstract delete(opts?: UpdateOpts): Promise<void>;
 
   /**
    * @returns The coerced data
    */
-  abstract create(data: T, opts?: SetOpts): Promise<T>;
-  abstract create(data: Partial<T>, opts?: SetOpts): Promise<Partial<T>>;
+  abstract create(data: T, opts?: UpdateOpts): Promise<T>;
+  abstract create(data: Partial<T>, opts?: UpdateOpts): Promise<Partial<T>>;
 
   /**
    * @returns The coerced data
    */
-  abstract update(data: T, opts?: SetOpts): Promise<T>;
-  abstract update(data: Partial<T>, opts?: SetOpts): Promise<Partial<T>>;
+  abstract update(data: T, opts?: UpdateOpts): Promise<T>;
+  abstract update(data: Partial<T>, opts?: UpdateOpts): Promise<Partial<T>>;
+
+  /**
+   * @returns The coerced data
+   */
+  abstract set(data: T, opts?: UpdateOpts): Promise<T>;
+  abstract set(data: Partial<T>, opts?: UpdateOpts): Promise<Partial<T>>;
 
   abstract get(): Promise<Snapshot<T>>;
 

--- a/src/relations.ts
+++ b/src/relations.ts
@@ -4,9 +4,10 @@ import type { StrapiModel, StrapiAttribute } from './types';
 import type { Transaction } from './db/transaction';
 import { RelationAttrInfo, RelationHandler, RelationInfo } from './utils/relation-handler';
 import { doesComponentRequireMetadata } from './utils/components-indexing';
-import type { Reference, SetOpts } from './db/reference';
+import type { Reference, UpdateOpts } from './db/reference';
+import type { EditMode } from './coerce/coerce-to-model';
 
-export function shouldUpdateRelations(opts: SetOpts | undefined): boolean {
+export function shouldUpdateRelations(opts: UpdateOpts | undefined): boolean {
   return !opts || (opts.updateRelations !== false);
 }
 
@@ -15,7 +16,7 @@ export function shouldUpdateRelations(opts: SetOpts | undefined): boolean {
  * Parse relation attributes on this updated model and update the referred-to
  * models accordingly.
  */
-export async function relationsUpdate<T extends object>(model: FirestoreConnectorModel<T>, ref: Reference<T>, prevData: T | undefined, newData: T | undefined, editMode: 'create' | 'update', transaction: Transaction) {
+export async function relationsUpdate<T extends object>(model: FirestoreConnectorModel<T>, ref: Reference<T>, prevData: T | undefined, newData: T | undefined, editMode: EditMode, transaction: Transaction) {
   await Promise.all(
     model.relations.map(r => r.update(ref, prevData, newData, editMode, transaction))
   );


### PR DESCRIPTION
- [ ] Implement the Firestore `set(...)` and `set(..., { merge: true })` operations on transactions and references
- [ ] Rationalise the write merging behaviour of transactions